### PR TITLE
Use prefab-cloud-js 0.1.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.7",
       "license": "ISC",
       "dependencies": {
-        "@prefab-cloud/prefab-cloud-js": "0.1.8"
+        "@prefab-cloud/prefab-cloud-js": "0.1.9"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^5.16.5",
@@ -1282,9 +1282,9 @@
       }
     },
     "node_modules/@prefab-cloud/prefab-cloud-js": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@prefab-cloud/prefab-cloud-js/-/prefab-cloud-js-0.1.8.tgz",
-      "integrity": "sha512-gp1LwEiPOBtkqPrt+ehdfEbUwM1BY1t7vAKvNVAJZXrHow8CuyOdLWJxQzgr6h/cqt6BghJMsc0DGHJG37hpSQ=="
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@prefab-cloud/prefab-cloud-js/-/prefab-cloud-js-0.1.9.tgz",
+      "integrity": "sha512-Mjpl+Dn0Byk2UWFNQFY1XJkSLmUJ4I9DF73EyLTd94cTlyAnmUD0+P6MCIWu/IPMoZPpFrtfWbnc9/196CV+JQ=="
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.24.27",
@@ -8344,9 +8344,9 @@
       }
     },
     "@prefab-cloud/prefab-cloud-js": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@prefab-cloud/prefab-cloud-js/-/prefab-cloud-js-0.1.8.tgz",
-      "integrity": "sha512-gp1LwEiPOBtkqPrt+ehdfEbUwM1BY1t7vAKvNVAJZXrHow8CuyOdLWJxQzgr6h/cqt6BghJMsc0DGHJG37hpSQ=="
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@prefab-cloud/prefab-cloud-js/-/prefab-cloud-js-0.1.9.tgz",
+      "integrity": "sha512-Mjpl+Dn0Byk2UWFNQFY1XJkSLmUJ4I9DF73EyLTd94cTlyAnmUD0+P6MCIWu/IPMoZPpFrtfWbnc9/196CV+JQ=="
     },
     "@sinclair/typebox": {
       "version": "0.24.27",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "Jeffrey Chupp",
   "license": "ISC",
   "dependencies": {
-    "@prefab-cloud/prefab-cloud-js": "0.1.8"
+    "@prefab-cloud/prefab-cloud-js": "0.1.9"
   },
   "keywords": [
     "feature-flags",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,14 +1,17 @@
-import React from 'react';
+import React from "react";
 import {
-  prefab, ConfigValue, Context, Identity,
-} from '@prefab-cloud/prefab-cloud-js';
+  prefab,
+  ConfigValue,
+  Context,
+  Identity,
+} from "@prefab-cloud/prefab-cloud-js";
 
 type IdentityAttributes = undefined | { [key: string]: any };
 
 type ContextAttributes = { [key: string]: Record<string, ConfigValue> };
 
 type ProvidedContext = {
-  get: (key: string) => any;
+  get: (_: string) => any;
   hasStartedInit: boolean;
   identityAttributes?: IdentityAttributes;
   contextAttributes?: ContextAttributes;
@@ -58,10 +61,10 @@ function PrefabProvider({
   const [loading, setLoading] = React.useState(true);
   // Here we track the current identity so we can reload our config when it
   // changes
-  const [loadedContextKey, setLoadedContextKey] = React.useState('');
+  const [loadedContextKey, setLoadedContextKey] = React.useState("");
 
   if (!identityAttributes && Object.keys(contextAttributes).length === 0) {
-    throw new Error('You must provide contextAttributes');
+    throw new Error("You must provide contextAttributes");
   }
 
   React.useEffect(() => {
@@ -77,9 +80,9 @@ function PrefabProvider({
 
     if (identityAttributes) {
       console.warn(
-        'identityAttributes is deprecated and will be removed in a future release. Please use contextAttributes instead',
+        "identityAttributes is deprecated and will be removed in a future release. Please use contextAttributes instead"
       );
-      initOptions.context = new Identity('', identityAttributes).toContext();
+      initOptions.context = new Identity("", identityAttributes).toContext();
     } else {
       initOptions.context = new Context(contextAttributes);
     }
@@ -101,7 +104,14 @@ function PrefabProvider({
           onError(reason);
         });
     }
-  }, [apiKey, loadedContextKey, identityAttributes, loading, setLoading, onError]);
+  }, [
+    apiKey,
+    loadedContextKey,
+    identityAttributes,
+    loading,
+    setLoading,
+    onError,
+  ]);
 
   const value: ProvidedContext = React.useMemo(
     () => ({
@@ -112,16 +122,13 @@ function PrefabProvider({
       loading,
       hasStartedInit: hasStartedInit.current,
     }),
-    [identityAttributes, loading, prefab],
+    [identityAttributes, loading, prefab]
   );
 
-  return <PrefabContext.Provider value={value}>{children}</PrefabContext.Provider>;
+  return (
+    <PrefabContext.Provider value={value}>{children}</PrefabContext.Provider>
+  );
 }
-
-PrefabProvider.defaultProps = {
-  timeout: undefined,
-  endpoints: undefined,
-};
 
 type TestProps = {
   config: { [key: string]: any };
@@ -141,12 +148,19 @@ function PrefabTestProvider({ config, children }: TestProps) {
       hasStartedInit: true,
       prefab,
     }),
-    [config],
+    [config]
   );
 
-  return <PrefabContext.Provider value={value}>{children}</PrefabContext.Provider>;
+  return (
+    <PrefabContext.Provider value={value}>{children}</PrefabContext.Provider>
+  );
 }
 
 export {
-  PrefabProvider, PrefabTestProvider, usePrefab, TestProps, Props,
+  PrefabProvider,
+  PrefabTestProvider,
+  usePrefab,
+  TestProps,
+  Props,
+  prefab,
 };


### PR DESCRIPTION
Also some formatting fixes

Most interestingly, this exports the `prefab` instance and the upgrade 0.1.9 upgrade exposes `shouldLog`