### PR TITLE
Version 0.1.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog
 
+## 0.1.20 - 2023-12-11
+
+- Use correct client version string
+
 ## 0.1.19 - 2023-10-24
 
 - Start reporting evaluation telemetry when keys are actually used

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 Changelog
 
-## 0.1.20 - 2023-12-11
+## 0.1.21 - 2023-12-11
 
 - Use correct client version string
+
+## 0.1.20 - 2023-10-31
+
+- Opt-in param for logger telemetry
 
 ## 0.1.19 - 2023-10-24
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prefab-cloud/prefab-cloud-react",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prefab-cloud/prefab-cloud-react",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "license": "ISC",
       "dependencies": {
         "@prefab-cloud/prefab-cloud-js": "0.1.19"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prefab-cloud/prefab-cloud-react",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prefab-cloud/prefab-cloud-react",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "license": "ISC",
       "dependencies": {
         "@prefab-cloud/prefab-cloud-js": "0.1.19"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prefab-cloud/prefab-cloud-react",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "FeatureFlags & Dynamic Configuration as a Service",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prefab-cloud/prefab-cloud-react",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "FeatureFlags & Dynamic Configuration as a Service",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 // THIS FILE IS GENERATED
-export default "0.1.19";
+export default "0.1.21";


### PR DESCRIPTION
Explanation for the apparent version jump here:

It looks like I really released 0.1.20 back in October, but never merged the associated branch with the changelog and new version numbers. Then when doing this release, I thought that my old .20 branch was an error and deleted it without merging.