### PR TITLE
Drop react-dom peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,13 +31,13 @@
         "jest": "^28.1.3",
         "jest-environment-jsdom": "^28.1.3",
         "prettier": "^3.0.0",
+        "react-dom": ">= 16.0.0",
         "ts-jest": "^28.0.7",
         "ts-node": "^10.9.1",
         "typescript": "^4.7.4"
       },
       "peerDependencies": {
-        "react": ">= 16.0.0",
-        "react-dom": ">= 16.0.0"
+        "react": ">= 16.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -6419,7 +6419,7 @@
     "node_modules/react-dom": {
       "version": "18.2.0",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -6622,7 +6622,7 @@
     "node_modules/scheduler": {
       "version": "0.23.0",
       "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -12361,7 +12361,7 @@
     "react-dom": {
       "version": "18.2.0",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -12500,7 +12500,7 @@
     "scheduler": {
       "version": "0.23.0",
       "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -43,12 +43,12 @@
     "jest": "^28.1.3",
     "jest-environment-jsdom": "^28.1.3",
     "prettier": "^3.0.0",
+    "react-dom": ">= 16.0.0",
     "ts-jest": "^28.0.7",
     "ts-node": "^10.9.1",
     "typescript": "^4.7.4"
   },
   "peerDependencies": {
-    "react": ">= 16.0.0",
-    "react-dom": ">= 16.0.0"
+    "react": ">= 16.0.0"
   }
 }


### PR DESCRIPTION
I think we can get by with this only being a dependency for tests.
