### PR TITLE
Allow for multiple Providers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,5 +15,3 @@ jobs:
         run: npm run test
       - name: Run lints
         run: npm run lint
-      - name: Run Prettier
-        run: npm run prettier

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "jest": "^28.1.3",
         "jest-environment-jsdom": "^28.1.3",
+        "jest-fetch-mock": "^3.0.3",
         "prettier": "^3.0.0",
         "react-dom": ">= 16.0.0",
         "ts-jest": "^28.0.7",
@@ -2530,6 +2531,15 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
+    "node_modules/cross-fetch": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "dev": true,
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -4876,6 +4886,16 @@
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
     },
+    "node_modules/jest-fetch-mock": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz",
+      "integrity": "sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==",
+      "dev": true,
+      "dependencies": {
+        "cross-fetch": "^3.0.4",
+        "promise-polyfill": "^8.1.3"
+      }
+    },
     "node_modules/jest-get-type": {
       "version": "28.0.2",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
@@ -5899,6 +5919,48 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -6334,6 +6396,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/promise-polyfill": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.3.0.tgz",
+      "integrity": "sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==",
+      "dev": true
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -9462,6 +9530,15 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
+    "cross-fetch": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "^2.6.12"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -11189,6 +11266,16 @@
         "jest-util": "^28.1.3"
       }
     },
+    "jest-fetch-mock": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz",
+      "integrity": "sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==",
+      "dev": true,
+      "requires": {
+        "cross-fetch": "^3.0.4",
+        "promise-polyfill": "^8.1.3"
+      }
+    },
     "jest-get-type": {
       "version": "28.0.2",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
@@ -11990,6 +12077,39 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+          "dev": true
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "dev": true,
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -12297,6 +12417,12 @@
           "dev": true
         }
       }
+    },
+    "promise-polyfill": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.3.0.tgz",
+      "integrity": "sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==",
+      "dev": true
     },
     "prompts": {
       "version": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "jest": "^28.1.3",
     "jest-environment-jsdom": "^28.1.3",
+    "jest-fetch-mock": "^3.0.3",
     "prettier": "^3.0.0",
     "react-dom": ">= 16.0.0",
     "ts-jest": "^28.0.7",

--- a/src/multiple.contexts.test.tsx
+++ b/src/multiple.contexts.test.tsx
@@ -1,0 +1,118 @@
+import React from "react";
+import "@testing-library/jest-dom/extend-expect";
+import { render, screen } from "@testing-library/react";
+import { Context as PrefabContext } from "@prefab-cloud/prefab-cloud-js";
+import fetchMock, { enableFetchMocks } from "jest-fetch-mock";
+import { PrefabProvider, usePrefab, defaultContext, ContextAttributes } from "./index";
+
+enableFetchMocks();
+
+const InnerPrefabContext = React.createContext(defaultContext);
+InnerPrefabContext.displayName = "InnerPrefabContext";
+const useInnerUserPrefab = () => React.useContext(InnerPrefabContext);
+
+function InnerUserComponent() {
+  const { get, isEnabled, loading } = useInnerUserPrefab();
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div>
+      <h1 data-testid="inner-greeting">{get("greeting") ?? "Default"}</h1>
+      {isEnabled("secretFeature") && (
+        <button data-testid="inner-secret-feature" type="submit" title="secret-feature">
+          Secret feature
+        </button>
+      )}
+    </div>
+  );
+}
+
+function OuterUserComponent({ user }: { user: { name: string } }) {
+  const { get, isEnabled, loading } = usePrefab();
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div>
+      <h1 data-testid="outer-greeting">{get("greeting") ?? "Default"}</h1>
+      {isEnabled("secretFeature") && (
+        <button data-testid="outer-secret-feature" type="submit" title="secret-feature">
+          Secret feature
+        </button>
+      )}
+
+      <div>
+        <h1>You are looking at {user.name}</h1>
+        <InnerUserComponent />
+      </div>
+    </div>
+  );
+}
+function App({
+  outerUserContext,
+  innerUserContext,
+}: {
+  outerUserContext: ContextAttributes;
+  innerUserContext: ContextAttributes;
+}) {
+  // eslint-disable-next-line no-console
+  const onError = console.error;
+  const apiKey = "api-key";
+
+  return (
+    <PrefabProvider apiKey={apiKey} contextAttributes={outerUserContext} onError={onError}>
+      <PrefabProvider
+        // Our inner provider will use a different React Context
+        ContextToUse={InnerPrefabContext}
+        // and its own Prefab context
+        contextAttributes={innerUserContext}
+        apiKey={apiKey}
+        onError={onError}
+      >
+        <OuterUserComponent user={{ name: "John Doe" }} />
+      </PrefabProvider>
+    </PrefabProvider>
+  );
+}
+
+it("allows multiple providers", async () => {
+  const outerUserContext = { user: { email: "dr.smith@example.com", doctor: true } };
+  const innerUserContext = { user: { email: "patient@example.com", doctor: false } };
+
+  const outerUserFetchData = {
+    values: { greeting: { string: "Greetings, Doctor" }, secretFeature: { bool: true } },
+  };
+  const innerUserFetchData = {
+    values: { greeting: { string: "Hi" }, secretFeature: { bool: false } },
+  };
+
+  fetchMock.mockResponse((req) => {
+    if (req.url.includes(new PrefabContext(outerUserContext).encode())) {
+      return Promise.resolve({
+        body: JSON.stringify(outerUserFetchData),
+        status: 200,
+      });
+    }
+
+    return Promise.resolve({
+      body: JSON.stringify(innerUserFetchData),
+      status: 200,
+    });
+  });
+
+  render(<App outerUserContext={outerUserContext} innerUserContext={innerUserContext} />);
+
+  const outerGreeting = await screen.findByTestId("outer-greeting");
+  const innerGreeting = await screen.findByTestId("inner-greeting");
+
+  expect(outerGreeting).toHaveTextContent("Greetings, Doctor");
+  expect(innerGreeting).toHaveTextContent("Hi");
+
+  expect(screen.queryByTestId("outer-secret-feature")).toBeInTheDocument();
+  expect(screen.queryByTestId("inner-secret-feature")).not.toBeInTheDocument();
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "files": ["src/index.tsx", "src/index.test.tsx", "src/jest.setup.ts"],
+  "files": ["src/index.tsx", "src/index.test.tsx", "src/multiple.contexts.test.tsx", "src/jest.setup.ts"],
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
 


### PR DESCRIPTION
Allow for multiple Providers

This allows you to have a concept of inner and outer contexts.

This is valuable for situations where you have an admin (or similar)
user who is viewing the page as a user (or similar) should see it. This
allows you to have a "current user" context and any number of "user I'm
looking at" contexts.

How does it work?

- Initialize your own React Context and `use` hook.
- Pass the Context into `<PrefabProvider>` as `ContextToUse`
- Use your `use` hook to access that context
- Continue using the `usePrefab` hook to access the original
  `<PrefabProvider>`'s context

See the tests for an example.

