### PR TITLE
Support nested Prefab providers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "jest": "^28.1.3",
         "jest-environment-jsdom": "^28.1.3",
+        "jest-fetch-mock": "^3.0.3",
         "prettier": "^3.0.0",
         "react-dom": ">= 16.0.0",
         "ts-jest": "^28.0.7",
@@ -2530,6 +2531,15 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
+    "node_modules/cross-fetch": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "dev": true,
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -4876,6 +4886,16 @@
         "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
     },
+    "node_modules/jest-fetch-mock": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz",
+      "integrity": "sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==",
+      "dev": true,
+      "dependencies": {
+        "cross-fetch": "^3.0.4",
+        "promise-polyfill": "^8.1.3"
+      }
+    },
     "node_modules/jest-get-type": {
       "version": "28.0.2",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
@@ -5899,6 +5919,48 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -6334,6 +6396,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/promise-polyfill": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.3.0.tgz",
+      "integrity": "sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==",
+      "dev": true
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -9462,6 +9530,15 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
+    "cross-fetch": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "^2.6.12"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -11189,6 +11266,16 @@
         "jest-util": "^28.1.3"
       }
     },
+    "jest-fetch-mock": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz",
+      "integrity": "sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==",
+      "dev": true,
+      "requires": {
+        "cross-fetch": "^3.0.4",
+        "promise-polyfill": "^8.1.3"
+      }
+    },
     "jest-get-type": {
       "version": "28.0.2",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
@@ -11990,6 +12077,39 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+          "dev": true
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "dev": true,
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -12297,6 +12417,12 @@
           "dev": true
         }
       }
+    },
+    "promise-polyfill": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.3.0.tgz",
+      "integrity": "sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==",
+      "dev": true
     },
     "prompts": {
       "version": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "npm run build && jest --verbose dist/",
     "lint": "eslint --ext .ts,.tsx src/",
     "prettier": "prettier . -l",
-    "prettier:fix": "npm run prettier --write .",
+    "prettier:fix": "npx prettier --write .",
     "release": "npm run build && rm -rf dist/jest.config.js dist/src/*.test.js",
     "preversion": "npm run test",
     "postversion": "npm run release && git push && git push --tags"
@@ -42,6 +42,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "jest": "^28.1.3",
     "jest-environment-jsdom": "^28.1.3",
+    "jest-fetch-mock": "^3.0.3",
     "prettier": "^3.0.0",
     "react-dom": ">= 16.0.0",
     "ts-jest": "^28.0.7",

--- a/src/nested-providers.test.tsx
+++ b/src/nested-providers.test.tsx
@@ -1,0 +1,129 @@
+import React from "react";
+import "@testing-library/jest-dom/extend-expect";
+import { render, screen } from "@testing-library/react";
+import { Context as PrefabContext } from "@prefab-cloud/prefab-cloud-js";
+import fetchMock, { enableFetchMocks } from "jest-fetch-mock";
+import { prefab as globalPrefab, PrefabProvider, usePrefab, ContextAttributes } from "./index";
+
+enableFetchMocks();
+
+// eslint-disable-next-line no-console
+const onError = console.error;
+const apiKey = "api-key";
+
+function InnerUserComponent() {
+  const { isEnabled, loading, prefab } = usePrefab();
+
+  if (loading) {
+    return <div>Loading inner component...</div>;
+  }
+
+  return (
+    <div data-testid="inner-wrapper" data-prefab-instance-hash={prefab.instanceHash}>
+      <h1 data-testid="inner-greeting">{prefab.get("greeting")?.toString() ?? "Default"}</h1>
+      {isEnabled("secretFeature") && (
+        <button data-testid="inner-secret-feature" type="submit" title="secret-feature">
+          Secret feature
+        </button>
+      )}
+    </div>
+  );
+}
+
+function OuterUserComponent({
+  admin,
+  innerUserContext,
+}: {
+  admin: { name: string };
+  innerUserContext: ContextAttributes;
+}) {
+  const { get, isEnabled, loading, prefab } = usePrefab();
+
+  if (loading) {
+    return <div>Loading outer component...</div>;
+  }
+
+  return (
+    <div data-testid="outer-wrapper" data-prefab-instance-hash={prefab.instanceHash}>
+      <h1 data-testid="outer-greeting">{get("greeting") ?? "Default"}</h1>
+      {isEnabled("secretFeature") && (
+        <button data-testid="outer-secret-feature" type="submit" title="secret-feature">
+          Secret feature
+        </button>
+      )}
+
+      <div>
+        <h1>You are looking at {admin.name}</h1>
+        <PrefabProvider apiKey={apiKey} contextAttributes={innerUserContext} onError={onError}>
+          <InnerUserComponent />
+        </PrefabProvider>
+      </div>
+    </div>
+  );
+}
+function App({
+  outerUserContext,
+  innerUserContext,
+}: {
+  outerUserContext: ContextAttributes;
+  innerUserContext: ContextAttributes;
+}) {
+  return (
+    <PrefabProvider apiKey={apiKey} contextAttributes={outerUserContext} onError={onError}>
+      <OuterUserComponent admin={{ name: "John Doe" }} innerUserContext={innerUserContext} />
+    </PrefabProvider>
+  );
+}
+
+it("allows nested `PrefabProvider`s", async () => {
+  const outerUserContext = {
+    user: { email: "dr.smith@example.com", doctor: true },
+    outerOnly: { city: "NYC" },
+  };
+  const innerUserContext = { user: { email: "patient@example.com", doctor: false } };
+
+  const outerUserFetchData = {
+    values: { greeting: { string: "Greetings, Doctor" }, secretFeature: { bool: true } },
+  };
+  const innerUserFetchData = {
+    values: { greeting: { string: "Hi" }, secretFeature: { bool: false } },
+  };
+
+  fetchMock.mockResponse((req) => {
+    if (req.url.includes(new PrefabContext(outerUserContext).encode())) {
+      return Promise.resolve({
+        body: JSON.stringify(outerUserFetchData),
+        status: 200,
+      });
+    }
+
+    return Promise.resolve({
+      body: JSON.stringify(innerUserFetchData),
+      status: 200,
+    });
+  });
+
+  render(<App outerUserContext={outerUserContext} innerUserContext={innerUserContext} />);
+
+  const outerGreeting = await screen.findByTestId("outer-greeting");
+  const innerGreeting = await screen.findByTestId("inner-greeting");
+
+  expect(outerGreeting).toHaveTextContent("Greetings, Doctor");
+  expect(innerGreeting).toHaveTextContent("Hi");
+
+  expect(screen.queryByTestId("outer-secret-feature")).toBeInTheDocument();
+  expect(screen.queryByTestId("inner-secret-feature")).not.toBeInTheDocument();
+
+  // Verify that each provider has its own copy of Prefab
+  const outerPrefabInstanceHash = screen
+    .getByTestId("outer-wrapper")
+    .getAttribute("data-prefab-instance-hash");
+  const innerPrefabInstanceHash = screen
+    .getByTestId("inner-wrapper")
+    .getAttribute("data-prefab-instance-hash");
+
+  expect(outerPrefabInstanceHash).toHaveLength(36);
+  expect(innerPrefabInstanceHash).toHaveLength(36);
+  expect(outerPrefabInstanceHash).not.toEqual(innerPrefabInstanceHash);
+  expect(outerPrefabInstanceHash).toEqual(globalPrefab.instanceHash);
+});

--- a/src/nested-test-providers.test.tsx
+++ b/src/nested-test-providers.test.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import "@testing-library/jest-dom/extend-expect";
+import { render, screen } from "@testing-library/react";
+import { prefab as globalPrefab, PrefabTestProvider, usePrefab, TestProps } from "./index";
+
+function InnerUserComponent() {
+  const { isEnabled, loading, prefab } = usePrefab();
+
+  if (loading) {
+    return <div>Loading inner component...</div>;
+  }
+
+  return (
+    <div data-testid="inner-wrapper" data-prefab-instance-hash={prefab.instanceHash}>
+      <h1 data-testid="inner-greeting">{prefab.get("greeting")?.toString() ?? "Default"}</h1>
+      {isEnabled("secretFeature") && (
+        <button data-testid="inner-secret-feature" type="submit" title="secret-feature">
+          Secret feature
+        </button>
+      )}
+    </div>
+  );
+}
+
+function OuterUserComponent({
+  admin,
+  innerTestConfig,
+}: {
+  admin: { name: string };
+  innerTestConfig: TestProps["config"];
+}) {
+  const { get, isEnabled, loading, prefab } = usePrefab();
+
+  if (loading) {
+    return <div>Loading outer component...</div>;
+  }
+
+  return (
+    <div data-testid="outer-wrapper" data-prefab-instance-hash={prefab.instanceHash}>
+      <h1 data-testid="outer-greeting">{get("greeting") ?? "Default"}</h1>
+      {isEnabled("secretFeature") && (
+        <button data-testid="outer-secret-feature" type="submit" title="secret-feature">
+          Secret feature
+        </button>
+      )}
+
+      <div>
+        <h1>You are looking at {admin.name}</h1>
+        <PrefabTestProvider config={innerTestConfig}>
+          <InnerUserComponent />
+        </PrefabTestProvider>
+      </div>
+    </div>
+  );
+}
+
+function App({
+  innerTestConfig,
+  outerTestConfig,
+}: {
+  innerTestConfig: TestProps["config"];
+  outerTestConfig: TestProps["config"];
+}) {
+  return (
+    <PrefabTestProvider config={outerTestConfig}>
+      <OuterUserComponent admin={{ name: "John Doe" }} innerTestConfig={innerTestConfig} />
+    </PrefabTestProvider>
+  );
+}
+
+it("allows nested test `PrefabTestProvider`s", async () => {
+  const outerUserContext = {
+    user: { email: "dr.smith@example.com", doctor: true },
+    outerOnly: { city: "NYC" },
+  };
+  const innerUserContext = { user: { email: "patient@example.com", doctor: false } };
+
+  const outerTestConfig = {
+    contextAttributes: outerUserContext,
+    greeting: "Greetings, Doctor",
+    secretFeature: true,
+  };
+
+  const innerTestConfig = {
+    contextAttributes: innerUserContext,
+    greeting: "Hi",
+    secretFeature: false,
+  };
+
+  render(<App outerTestConfig={outerTestConfig} innerTestConfig={innerTestConfig} />);
+
+  const outerGreeting = await screen.findByTestId("outer-greeting");
+  const innerGreeting = await screen.findByTestId("inner-greeting");
+
+  expect(outerGreeting).toHaveTextContent("Greetings, Doctor");
+  expect(innerGreeting).toHaveTextContent("Hi");
+
+  expect(screen.queryByTestId("outer-secret-feature")).toBeInTheDocument();
+  expect(screen.queryByTestId("inner-secret-feature")).not.toBeInTheDocument();
+
+  // Verify that each provider has its own copy of Prefab
+  const outerPrefabInstanceHash = screen
+    .getByTestId("outer-wrapper")
+    .getAttribute("data-prefab-instance-hash");
+  const innerPrefabInstanceHash = screen
+    .getByTestId("inner-wrapper")
+    .getAttribute("data-prefab-instance-hash");
+
+  expect(outerPrefabInstanceHash).toHaveLength(36);
+  expect(innerPrefabInstanceHash).toHaveLength(36);
+  expect(outerPrefabInstanceHash).not.toEqual(innerPrefabInstanceHash);
+  expect(outerPrefabInstanceHash).toEqual(globalPrefab.instanceHash);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,11 @@
 {
-  "files": ["src/index.tsx", "src/index.test.tsx", "src/jest.setup.ts"],
+  "files": [
+    "src/index.tsx",
+    "src/index.test.tsx",
+    "src/nested-providers.test.tsx",
+    "src/nested-test-providers.test.tsx",
+    "src/jest.setup.ts"
+  ],
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
 


### PR DESCRIPTION
This allows for nesting different Prefab contexts. You can (e.g.) have an admin view that wraps a user that you're viewing and have proper contexts for each.

Imagine

```jsx
<PrefabProvider apiKey={apiKey} contextAttributes={adminUser}>
  <Greeting />
  <PrefabProvider apiKey={apiKey} contextAttributes={userBeingViewed}>
    <Greeting />
  </PrefabProvider>
</PrefabProvider>
```

The first `Greeting` component can `usePrefab` and be bound to the `adminUser` Prefab context and their evaluated flags/configs.

The second `Greeting` component can `usePrefab` and be bound to the `userBeingViewed` Prefab context and their evaluated flags/configs.

Neither `Greeting` component needs to worry about which context it is being evaluated in.

Each `PrefabProvider` has its own Prefab JS client for true isolation.