### PR TITLE
Allow nesting PrefabProvider in PrefabTestProvider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prefab-cloud/prefab-cloud-react",
-  "version": "0.3.1",
+  "version": "0.3.2-pre.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prefab-cloud/prefab-cloud-react",
-      "version": "0.3.1",
+      "version": "0.3.2-pre.1",
       "license": "ISC",
       "dependencies": {
         "@prefab-cloud/prefab-cloud-js": "0.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prefab-cloud/prefab-cloud-react",
-  "version": "0.3.1",
+  "version": "0.3.2-pre.1",
   "description": "FeatureFlags & Dynamic Configuration as a Service",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -185,9 +185,10 @@ function PrefabProvider({
 
 type TestProps = {
   config: Record<string, any>;
+  apiKey?: string;
 };
 
-function PrefabTestProvider({ config, children }: PropsWithChildren<TestProps>) {
+function PrefabTestProvider({ apiKey, config, children }: PropsWithChildren<TestProps>) {
   const get = (key: string) => config[key];
   const getDuration = (key: string) => config[key];
   const isEnabled = (key: string) => !!get(key);
@@ -206,7 +207,7 @@ function PrefabTestProvider({ config, children }: PropsWithChildren<TestProps>) 
       loading: false,
       prefab: prefabClient,
       keys: Object.keys(config),
-      settings: {},
+      settings: { apiKey: apiKey ?? "fake-api-key-via-the-test-provider" },
     };
   }, [config]);
 

--- a/src/nested-test-providers.test.tsx
+++ b/src/nested-test-providers.test.tsx
@@ -1,7 +1,30 @@
 import React from "react";
 import "@testing-library/jest-dom/extend-expect";
-import { render, screen } from "@testing-library/react";
-import { prefab as globalPrefab, PrefabTestProvider, usePrefab, TestProps } from "./index";
+import { act, render, screen } from "@testing-library/react";
+import {
+  prefab as globalPrefab,
+  PrefabTestProvider,
+  usePrefab,
+  TestProps,
+  PrefabProvider,
+} from "./index";
+
+type Provider = typeof PrefabTestProvider | typeof PrefabProvider;
+
+type Config = { [key: string]: any };
+
+const stubConfig = (config: Config) =>
+  new Promise((resolve) => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => {
+          setTimeout(resolve);
+          return { values: config };
+        },
+      })
+    ) as jest.Mock;
+  });
 
 function InnerUserComponent() {
   const { isEnabled, loading, prefab } = usePrefab();
@@ -25,11 +48,13 @@ function InnerUserComponent() {
 function OuterUserComponent({
   admin,
   innerTestConfig,
+  InnerProvider,
 }: {
   admin: { name: string };
   innerTestConfig: TestProps["config"];
+  InnerProvider: Provider;
 }) {
-  const { get, isEnabled, loading, prefab } = usePrefab();
+  const { get, isEnabled, loading, prefab, settings } = usePrefab();
 
   if (loading) {
     return <div>Loading outer component...</div>;
@@ -46,9 +71,14 @@ function OuterUserComponent({
 
       <div>
         <h1>You are looking at {admin.name}</h1>
-        <PrefabTestProvider config={innerTestConfig}>
+        <InnerProvider
+          config={innerTestConfig}
+          /* eslint-disable-next-line react/jsx-props-no-spreading */
+          {...settings}
+          contextAttributes={{ user: { email: "test@example.com" } }}
+        >
           <InnerUserComponent />
-        </PrefabTestProvider>
+        </InnerProvider>
       </div>
     </div>
   );
@@ -57,13 +87,19 @@ function OuterUserComponent({
 function App({
   innerTestConfig,
   outerTestConfig,
+  InnerProvider,
 }: {
   innerTestConfig: TestProps["config"];
   outerTestConfig: TestProps["config"];
+  InnerProvider: Provider;
 }) {
   return (
     <PrefabTestProvider config={outerTestConfig}>
-      <OuterUserComponent admin={{ name: "John Doe" }} innerTestConfig={innerTestConfig} />
+      <OuterUserComponent
+        admin={{ name: "John Doe" }}
+        innerTestConfig={innerTestConfig}
+        InnerProvider={InnerProvider}
+      />
     </PrefabTestProvider>
   );
 }
@@ -87,7 +123,13 @@ it("allows nested test `PrefabTestProvider`s", async () => {
     secretFeature: false,
   };
 
-  render(<App outerTestConfig={outerTestConfig} innerTestConfig={innerTestConfig} />);
+  render(
+    <App
+      outerTestConfig={outerTestConfig}
+      innerTestConfig={innerTestConfig}
+      InnerProvider={PrefabTestProvider}
+    />
+  );
 
   const outerGreeting = await screen.findByTestId("outer-greeting");
   const innerGreeting = await screen.findByTestId("inner-greeting");
@@ -110,4 +152,55 @@ it("allows nested test `PrefabTestProvider`s", async () => {
   expect(innerPrefabInstanceHash).toHaveLength(36);
   expect(outerPrefabInstanceHash).not.toEqual(innerPrefabInstanceHash);
   expect(outerPrefabInstanceHash).toEqual(globalPrefab.instanceHash);
+});
+
+it("can nest a real provider within a test provider", async () => {
+  const outerUserContext = {
+    user: { email: "dr.smith@example.com", doctor: true },
+    outerOnly: { city: "NYC" },
+  };
+  const innerUserContext = { user: { email: "patient@example.com", doctor: false } };
+
+  const outerTestConfig = {
+    contextAttributes: outerUserContext,
+    greeting: "Greetings, Doctor",
+    secretFeature: true,
+  };
+
+  const innerTestConfig = {
+    contextAttributes: innerUserContext,
+    greeting: "Hi",
+    secretFeature: false,
+  };
+
+  const promise = stubConfig(innerTestConfig);
+
+  render(
+    <App outerTestConfig={outerTestConfig} innerTestConfig={{}} InnerProvider={PrefabProvider} />
+  );
+
+  await act(async () => {
+    await promise;
+  });
+
+  const outerGreeting = await screen.findByTestId("outer-greeting");
+  const innerGreeting = await screen.findByTestId("inner-greeting");
+
+  expect(outerGreeting).toHaveTextContent("Greetings, Doctor");
+  expect(innerGreeting).toHaveTextContent("Hi");
+
+  expect(screen.queryByTestId("outer-secret-feature")).toBeInTheDocument();
+  expect(screen.queryByTestId("inner-secret-feature")).not.toBeInTheDocument();
+
+  // Verify that each provider has its own copy of Prefab
+  const outerPrefabInstanceHash = screen
+    .getByTestId("outer-wrapper")
+    .getAttribute("data-prefab-instance-hash");
+  const innerPrefabInstanceHash = screen
+    .getByTestId("inner-wrapper")
+    .getAttribute("data-prefab-instance-hash");
+
+  expect(outerPrefabInstanceHash).toHaveLength(36);
+  expect(innerPrefabInstanceHash).toHaveLength(36);
+  expect(outerPrefabInstanceHash).not.toEqual(innerPrefabInstanceHash);
 });

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 // THIS FILE IS GENERATED
-export default "0.3.1";
+export default "0.3.2-pre.1";


### PR DESCRIPTION
This allows for the scenario where you set a global `PrefabTestProvider`
in your tests but your components down the line want to use a nested
`PrefabProvider` (presumably with MSW or some other fetch mocking)
